### PR TITLE
Use full github link for ottypes/docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ markdown.
 
 This project's [history is here](https://github.com/share/ShareJS/blob/0.6/src/types/text2.coffee).
 
-For documentation on the spec this type implements, see [ottypes/docs](/ottypes/docs).
+For documentation on the spec this type implements, see [ottypes/docs](https://github.com/ottypes/docs).
 
 ## Spec
 


### PR DESCRIPTION
Change the /ottypes/docs link in the README.md to use the full url.  Otherwise github creates a link relative to the source tree.
